### PR TITLE
As3.0

### DIFF
--- a/AndroidStudioPortable-Definitions.ps1
+++ b/AndroidStudioPortable-Definitions.ps1
@@ -27,12 +27,11 @@ $AndroidSDKBinariesDirectories = @(
 )
 
 $AndroidStudio =
-    'android-studio-ide-162.4069837-windows'
+    'android-studio-ide-171.4443003-windows'
 $AndroidStudioArchive =
     "$AndroidStudio.zip"
 $AndroidStudioURL =
-    'https://dl.google.com/dl/android/studio/ide-zips/2.3.3.0/' +
-        $AndroidStudioArchive
+    "https://dl.google.com/dl/android/studio/ide-zips/3.0.1.0/$AndroidStudioArchive"
 $AndroidStudioDirectory =
     ".\$AndroidStudio\android-studio"
 $AndroidStudioBinariesDirectory =
@@ -40,7 +39,7 @@ $AndroidStudioBinariesDirectory =
 $AndroidStudioUserHomeDirectory =
     "`${idea.home}/../../$PortabelHomeDirectoryName"
 $AndroidStudioHomeDirectory =
-    "$AndroidStudioUserHomeDirectory/.AndroidStudio2.3"
+    "$AndroidStudioUserHomeDirectory/.AndroidStudio3.0"
 $AndroidStudioExecutable =
     'studio64.exe'
 $AndroidStudioConfigurationFile =
@@ -64,11 +63,11 @@ $GradleUserHomeDirectory =
     "$PortableHomeDirectory\.gradle"
 
 $OracleJDK =
-    'jdk-8u131-windows-x64'
+    'jdk-8u151-windows-x64'
 $OracleJDKInstaller =
     "$OracleJDK.exe"
 $OracleJDKURL =
-    "http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/$OracleJDKInstaller"
+    "http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/$OracleJDKInstaller"
 $OracleJDKInternalCABPath =
     '.rsrc\1033\JAVA_CAB10'
 $OracleJDKInternalCAB =

--- a/Setup-AndroidStudioPortable.ps1
+++ b/Setup-AndroidStudioPortable.ps1
@@ -36,9 +36,10 @@ if ($ToolsAreRequired -And !(Test-Path -Path $LessMSIDirectory))
 {
     if (!(Test-Path -Path $LessMSIArchive))
     {
+        Write-Output "Get LessMSI"
         Invoke-WebRequest -Uri $LessMSIURL -OutFile $LessMSIArchive
     }
-
+    Write-Output "Expand LessMSI"
     Expand-Archive -Path $LessMSIArchive
 }
 
@@ -50,9 +51,11 @@ if ($ToolsAreRequired -And !(Test-Path -Path $7zDirectory))
 {
     if (!(Test-Path -Path $7zInstaller))
     {
+        Write-Output "Get 7-Zip"
         Invoke-WebRequest -Uri $7zURL -OutFile $7zInstaller
     }
 
+    Write-Output "Use LessMSI to unpack 7zip"
     & ".\$LessMSIDirectory\$LessMSIExecutable" 'x' $7zInstaller
 }
 
@@ -64,9 +67,11 @@ if (!(Test-Path -Path $AndroidStudioDirectory))
 {
     if (!(Test-Path -Path $AndroidStudioArchive))
     {
+        Write-Output "Download Android Studio $AndroidStudio"
         Invoke-WebRequest -Uri $AndroidStudioURL -OutFile $AndroidStudioArchive
     }
 
+    Write-Output "Unpacking Android Studio"
     & ".\$7zDirectory\$7zExecutable" 'x' $AndroidStudioArchive '-o*' '-y'
 }
 
@@ -116,6 +121,7 @@ if (!(Test-Path -Path $OracleJDKDirectory))
                     OutFile = $OracleJDKInstaller;
                     Cookies = $Cookies;
                 }
+                Write-Output "Download Java JDK $OracleJDK"
                 Invoke-WebRequestWithCookies @InvokeWebRequestParameters
             }
 
@@ -123,6 +129,7 @@ if (!(Test-Path -Path $OracleJDKDirectory))
             # Unpack the Oracle JDK installer with 7-Zip.
             #
 
+            Write-Output "Unpack JDK installer"
             & ".\$7zDirectory\$7zExecutable"                      `
                 'e' $OracleJDKInstaller                           `
                 "$OracleJDKInternalCABPath\$OracleJDKInternalCAB" `
@@ -133,11 +140,13 @@ if (!(Test-Path -Path $OracleJDKDirectory))
         # Unpack the Oracle JDK Tools CAB with 7-Zip.
         #
 
+        Write-Output "Unpack JDK archive"
         & ".\$7zDirectory\$7zExecutable"     `
             'e' $OracleJDKInternalCAB        `
             "$OracleJDKInternalArchive" '-y'
     }
 
+    Write-Output "Unpack JDK"
     & ".\$7zDirectory\$7zExecutable" 'x' $OracleJDKInternalArchive `
                                      "-o$OracleJDKDirectory" '-y'
 }
@@ -147,6 +156,7 @@ if (!(Test-Path -Path $OracleJDKDirectory))
 # utility bundled with the JDK.
 #
 
+Write-Output "Expand JDK files"
 $GetChildItemParameters = @{
     Path = $OracleJDKDirectory;
     Filter = '*.pack';
@@ -223,7 +233,6 @@ foreach ($VMConfigurationFile in $AndroidStudioVMConfigurationFiles)
 #
 # Remove temporary files.
 #
-
 $LessMSIRootDirectory =
     Get-RelativeRootDirectory -RelativePath $LessMSIDirectory
 $7zRootDirectory =


### PR DESCRIPTION
This successfully will download and create an installation for Android Studio 3.0.1 with JDK 8u151. Home directory was bumped to .AndroidStudio3.0 to not interfere with 2.3 installs even though that shouldn't matter. Using the update feature offered automatically by 2.3 caused my system to break. This gets me a full 3.0 environment and leaves the 2.3 alone. 